### PR TITLE
Port embedding code to PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ cd librascal
 pip install .
 ```
 
+If your environment requires a [PyTorch](https://pytorch.org/)
+version less than 2.0, then you will also need the additional
+[functorch](https://github.com/pytorch/functorch) package to access the
+[grad_and_value](https://pytorch.org/functorch/stable/generated/functorch.grad_and_value.html) function. This can be installed from `conda-forge` as follows:
+
+```sh
+conda install -c conda-forge functorch
+```
+
+(It may be necessary to specify `functorch` as an additional dependency at the
+environment creation stage, e.g. if it is not possible to resolve with the
+above approach.)
+
 Finally, install the `sander-mlmm` interface:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ modifications to sander are needed.
 First create a conda environment with all of the required dependencies:
 
 ```sh
-conda create -n mlmm -c conda-forge ambertools ase compilers eigen deepmd-kit pytorch-gpu torchani
+conda env create -f environment.yml
 conda activate mlmm
 ```
 
@@ -21,27 +21,6 @@ If this fails, try using [mamba](https://github.com/mamba-org/mamba) as a replac
 For GPU functionality, you will need to install appropriate CUDA drivers on
 your host system along with NVCC, the CUDA compiler driver. (This doesn't come
 with `cudatoolkit` from `conda-forge`.)
-
-Now install the additional, non-conda, [librascal](https://github.com/lab-cosmo/librascal) package:
-
-```sh
-git clone https://github.com/lab-cosmo/librascal.git
-cd librascal
-pip install .
-```
-
-If your environment requires a [PyTorch](https://pytorch.org/)
-version less than 2.0, then you will also need the additional
-[functorch](https://github.com/pytorch/functorch) package to access the
-[grad_and_value](https://pytorch.org/functorch/stable/generated/functorch.grad_and_value.html) function. This can be installed from `conda-forge` as follows:
-
-```sh
-conda install -c conda-forge functorch
-```
-
-(It may be necessary to specify `functorch` as an additional dependency at the
-environment creation stage, e.g. if it is not possible to resolve with the
-above approach.)
 
 Finally, install the `sander-mlmm` interface:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ modifications to sander are needed.
 First create a conda environment with all of the required dependencies:
 
 ```sh
-CONDA_OVERRIDE_CUDA="11.2" conda create -n mlmm -c conda-forge ambertools ase compilers cudatoolkit=11.2 cudatoolkit-dev=11.2 eigen deepmd-kit jax jaxlib=\*=cuda\* pytorch-gpu torchani
+conda create -n mlmm -c conda-forge ambertools ase compilers eigen deepmd-kit pytorch-gpu torchani
 conda activate mlmm
 ```
 
@@ -115,7 +115,7 @@ recommend the use of absolute paths.
 The ML/MM implementation uses several ML frameworks to predict energies
 and gradients. [DeePMD-kit](https://docs.deepmodeling.com/projects/deepmd/en/master/index.html)
 or [TorchANI](https://github.com/aiqm/torchani) can be used for the in vacuo
-predictions and custom [JAX](https://github.com/google/jax) code is used to predict
+predictions and custom [PyTorch](https://pytorch.org) code is used to predict
 corrections to the in vacuo values in the presence of point charges.
 The frameworks make heavy use of
 [just-in-time compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation).
@@ -138,16 +138,6 @@ Output will be written to the `demo/output` directory.
 
 ## Issues
 
-By default, when a GPU is available, [JAX](https://github.com/google/jax) will preallocate 90% of the total
-memory when the first operation is run. (See [here](https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html)
-for details.) While this is designed to minimise allocation overhead and
-memory fragmentation, it can result in an "out of memory" error if the
-GPU is already partially utilised. In this case, setting the following
-environment variable will disable preallocation.
-
-```
-XLA_PYTHON_CLIENT_PREALLOCATE=false
-```
 The [DeePMD-kit](https://docs.deepmodeling.com/projects/deepmd/en/master/index.html) conda package pulls in a version of MPI which may cause
 problems if using [ORCA](https://orcaforum.kofo.mpg.de/index.php) as the in vacuo backend, particularly when running
 on HPC resources that might enforce a specific MPI setup. (ORCA will

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ When multiple files are specified, energies and gradients will be averaged
 over the models. The model files need to be visible to the `mlmm-server`, so we
 recommend the use of absolute paths.
 
+## Device
+
+We currently support `CPU` and `CUDA` as the device for [PyTorch](https://pytorch.org/).
+This can be configured using the `MLMM_DEVICE` environment variable, or by
+using the `--device` argument when launching `mlmm-server`, e.g.:
+
+```
+mlmm-server --backend cuda
+```
+
+When no device is specified, we will preferentially try to use `CUDA` if it is
+available. By default, the _first_ `CUDA` device index will be used. If you want
+to specify the index, e.g. when running on a multi-GPU setup, then you can use
+the following syntax:
+
+```
+mlmm-server --backend cuda:1
+```
+
+This would tell `PyTorch` that we want to use device index `1`. The same formatting
+works for the environment varialbe, e.g. `MLMM_DEVICE=cuda:1`.
+
 ## Why do we need an ML/MM server?
 
 The ML/MM implementation uses several ML frameworks to predict energies

--- a/bin/mlmm-server
+++ b/bin/mlmm-server
@@ -42,6 +42,7 @@ try:
 except:
     MLMM_NUM_CLIENTS = None
 MLMM_BACKEND = os.getenv("MLMM_BACKEND")
+MLMM_DEVICE = os.getenv("MLMM_DEVICE")
 MLMM_LOG = os.getenv("MLMM_LOG", "True").lower() in ("true", "1", "t")
 DEEPMD_MODEL = os.getenv("DEEPMD_MODEL")
 
@@ -54,6 +55,8 @@ if not MLMM_NUM_CLIENTS:
     MLMM_NUM_CLIENTS = 1
 if not MLMM_BACKEND:
     MLMM_BACKEND = "torchani"
+if not MLMM_DEVICE:
+    MLMM_DEVICE = None
 
 
 def validate_clients(num_clients):
@@ -92,6 +95,13 @@ parser.add_argument(
     required=False,
 )
 parser.add_argument(
+    "--device",
+    type=str,
+    help="the device to be used by PyTorch",
+    choices=["cpu", "cuda"],
+    required=False,
+)
+parser.add_argument(
     "--deepmd-model",
     type=str,
     nargs="+",
@@ -117,6 +127,8 @@ if args.num_clients:
     MLMM_NUM_CLIENTS = args.num_clients
 if args.backend:
     MLMM_BACKEND = args.backend
+if args.device:
+    MLMM_DEVICE = args.device
 if args.deepmd_model:
     DEEPMD_MODEL = args.deepmd_model
 if args.log is not None:
@@ -173,7 +185,11 @@ except:
 # Create the ML/MM calculator.
 print("Initialising ML/MM calculator...")
 mlmm_calculator = MLMMCalculator(
-    model=MLMM_MODEL, backend=MLMM_BACKEND, deepmd_model=DEEPMD_MODEL, log=MLMM_LOG
+    model=MLMM_MODEL,
+    backend=MLMM_BACKEND,
+    deepmd_model=DEEPMD_MODEL,
+    device=MLMM_DEVICE,
+    log=MLMM_LOG,
 )
 
 while True:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: mlmm
+
+channels:
+  - conda-forge
+
+dependencies:
+  - ambertools
+  - ase
+  - eigen
+  - compilers
+  - deepmd-kit
+  - functorch
+  - pytorch-gpu >= 1.13
+  - torchani
+  - pip:
+    - git+https://github.com/lab-cosmo/librascal.git#egg=rascal[complete]

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - compilers
   - deepmd-kit
   - functorch
+  - pip
   - pytorch-gpu >= 1.13
   - torchani
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,8 @@ dependencies:
   - eigen
   - compilers
   - deepmd-kit
-  - functorch
   - pip
-  - pytorch-gpu >= 1.13
+  - pytorch-gpu >= 2.0
   - torchani
   - pip:
     - git+https://github.com/lab-cosmo/librascal.git#egg=rascal[complete]

--- a/mlmm/mlmm.py
+++ b/mlmm/mlmm.py
@@ -302,11 +302,11 @@ class MLMMCalculator:
                 except:
                     index = 0
 
-            # Make sure the GPU device index is valid.
-            try:
-                index = int(index)
-            except:
-                raise ValueError(f"Invalid GPU index: {index}") from None
+                # Make sure the GPU device index is valid.
+                try:
+                    index = int(index)
+                except:
+                    raise ValueError(f"Invalid GPU index: {index}") from None
 
             if not device in self._supported_devices:
                 raise ValueError(

--- a/mlmm/mlmm.py
+++ b/mlmm/mlmm.py
@@ -538,8 +538,8 @@ class MLMMCalculator:
 
         # Compute the total energy and gradients.
         E_tot = E + E_vac
-        grad_qm = np.array(dE_dxyz_qm_bohr.cpu()) + grad_vac
-        grad_mm = np.array(dE_dxyz_mm_bohr.cpu())
+        grad_qm = dE_dxyz_qm_bohr.cpu().numpy() + grad_vac
+        grad_mm = dE_dxyz_mm_bohr.cpu().numpy()
 
         # Create the file names for the ORCA format output.
         filename = os.path.splitext(orca_input)[0]

--- a/mlmm/mlmm.py
+++ b/mlmm/mlmm.py
@@ -527,6 +527,7 @@ class MLMMCalculator:
         ds_dxyz_qm_bohr = self._get_df_dxyz(ds_dsoap, dsoap_dxyz_qm_bohr)
         dchi_dxyz_qm_bohr = self._get_df_dxyz(dchi_dsoap, dsoap_dxyz_qm_bohr)
 
+        # Compute gradients and energy.
         grads, E = self._get_E_with_grad(charges_mm, xyz_qm_bohr, xyz_mm_bohr, s, chi)
         dE_dxyz_qm_bohr_part, dE_dxyz_mm_bohr, dE_ds, dE_dchi = grads
         dE_dxyz_qm_bohr = (

--- a/mlmm/mlmm.py
+++ b/mlmm/mlmm.py
@@ -301,6 +301,13 @@ class MLMMCalculator:
                     device, index = device.split(":")
                 except:
                     index = 0
+
+            # Make sure the GPU device index is valid.
+            try:
+                index = int(index)
+            except:
+                raise ValueError(f"Invalid GPU index: {index}") from None
+
             if not device in self._supported_devices:
                 raise ValueError(
                     f"Unsupported device '{device}'. Options are: {', '.join(self._supported_devices)}"


### PR DESCRIPTION
This PR ports the ML/MM embedding code from [JAX](https://github.com/google/jax) to [PyTorch](https://pytorch.org). This greatly simplifies our conda environment since we no longer need to resolve compatible versions of the aforementioned machine learning frameworks. This will also make it easier to embed our code into other tools, since the majority rely on PyTorch for ML functionality.

The translation to PyTorch was relatively simple, other than some subtle differences in behaviour with respect to NumPy, e.g. needing to switch `repeat` with `repeat_interleave`. The code relies on the the [grad_and_value](https://pytorch.org/docs/stable/generated/torch.func.grad_and_value.html?highlight=grad_and_value#torch.func.grad_and_value) function, which has only been part of the core PyTorch code since version 2.0. Previous to this, equivalent functionality was provided through the (additional) [functorch](https://pytorch.org/functorch/stable/generated/functorch.grad_and_value.html?highlight=grad_and_value#functorch.grad_and_value) package. The ML/MM code supports both via some simple `try/except` logic. Version 2.0 of PyTorch also brings in some other useful functions, such as `tensor.fill_diagonal`. Again, it is easy to support different versions of the API using `try/except`.

A simple test using 100 frames from an existing alanine-dipeptide trajectory shows that agreement for both energies and gradients between PyTorch and JAX is excellent.

![jax_vs_torch](https://github.com/lohedges/sander-mlmm/assets/648557/fad03c29-1fb5-4147-8baf-1670f277f5ce)

Basic benchmarks indicate that performance is roughly 2x in comparison to JAX and it is now easier to use the GPU throughout the entire calculation, since the in vacuo and embedding parts use the same framework. (I plan to test systems with different sized QM regions to better benchmark the scaling of CPU and GPU performance.)

With this port I have also updated the installation instructions to use an `environment.yml` file. This allows us to select for compatible versions of PyTorch, along with automatically installing the non-conda [librascal](https://github.com/lab-cosmo/librascal) dependency via `pip` at the environment creation stage. The user can now do the following to create a fully working environment:

```
conda env create -f environment.yml
```

I am currently re-running some existing simulations using the updated code and will merge once I'm happy that the results are in agreement with the previous runs. I will also profile the code to see if there are any easy performance gains.