### PR TITLE
Add support for rascal in-vacuo backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ mlmm-stop
 
 The embedding method relies on in vacuo energies and gradients, to which
 corrections are added based on the predictions of the model. At present we
-support the use of [DeePMD-kit](https://docs.deepmodeling.com/projects/deepmd/en/master/index.html), [TorchANI](https://githb.com/aiqm/torchani) or [ORCA](https://sites.google.com/site/orcainputlibrary/interfaces-and-qmm)
+support the use of [Rascal](https://github.com/lab-cosmo/librascal), [DeePMD-kit](https://docs.deepmodeling.com/projects/deepmd/en/master/index.html), [TorchANI](https://githb.com/aiqm/torchani) or [ORCA](https://sites.google.com/site/orcainputlibrary/interfaces-and-qmm)
 for the backend, providing reference QM with ML/MM embedding, and pure ML/MM
 implementations. To specify a backend, use the `--backend` argument when launching
 `mlmm-server`, e.g:
@@ -86,6 +86,12 @@ mlmm-server --backend torchani
 ```
 
 (The default backend is `torchani`.)
+
+When using the `rascal` backend you will also need to specify a model file
+and the AMBER parm7 topology file that was used to train this model. These
+can be specified using the `--rascal-model` and `--rascal-parm7` command-line
+arguments, or using the `RASCAL_MODEL` and `RASCAL_PARM7` environment variables.
+Rascal can be used to train system specific delta-learning models.
 
 When using the `orca` backend, you will need to ensure that the _fake_ `orca`
 executable takes precedence in the `PATH`. (To check that ML/MM is running,

--- a/bin/mlmm-server
+++ b/bin/mlmm-server
@@ -45,6 +45,8 @@ MLMM_BACKEND = os.getenv("MLMM_BACKEND")
 MLMM_DEVICE = os.getenv("MLMM_DEVICE")
 MLMM_LOG = os.getenv("MLMM_LOG", "True").lower() in ("true", "1", "t")
 DEEPMD_MODEL = os.getenv("DEEPMD_MODEL")
+RASCAL_MODEL = os.getenv("RASCAL_MODEL")
+RASCAL_PARM7 = os.getenv("RASCAL_PARM7")
 
 # Fallback to default values.
 if not MLMM_HOST:
@@ -91,7 +93,7 @@ parser.add_argument(
     "--backend",
     type=str,
     help="the in vacuo backend",
-    choices=["deepmd", "torchani", "orca"],
+    choices=["deepmd", "rascal", "torchani", "orca"],
     required=False,
 )
 parser.add_argument(
@@ -106,6 +108,20 @@ parser.add_argument(
     type=str,
     nargs="+",
     help="path to DeepMD model file(s)",
+    required=False,
+)
+parser.add_argument(
+    "--rascal-model",
+    type=str,
+    nargs="+",
+    help="path to Rascal model file",
+    required=False,
+)
+parser.add_argument(
+    "--rascal-parm7",
+    type=str,
+    nargs="+",
+    help="path to the parm7 file used to train the Rascal model",
     required=False,
 )
 parser.add_argument(
@@ -131,6 +147,10 @@ if args.device:
     MLMM_DEVICE = args.device
 if args.deepmd_model:
     DEEPMD_MODEL = args.deepmd_model
+if args.rascal_model:
+    RASCAL_MODEL = args.rascal_model
+if args.rascal_parm7:
+    RASCAL_PARM7 = args.rascal_parm7
 if args.log is not None:
     MLMM_LOG = args.log
 
@@ -188,6 +208,8 @@ mlmm_calculator = MLMMCalculator(
     model=MLMM_MODEL,
     backend=MLMM_BACKEND,
     deepmd_model=DEEPMD_MODEL,
+    rascal_model=RASCAL_MODEL,
+    rascal_parm7=RASCAL_PARM7,
     device=MLMM_DEVICE,
     log=MLMM_LOG,
 )

--- a/mlmm/sander_calculator.py
+++ b/mlmm/sander_calculator.py
@@ -1,0 +1,65 @@
+######################################################################
+# ML/MM: https://github.com/lohedges/sander-mlmm
+#
+# Copyright: 2023
+#
+# Authors: Lester Hedges   <lester.hedges@gmail.com>
+#          Kirill Zinovjev <kzinovjev@gmail.com>
+#
+# ML/MM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# ML/MM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ML/MM. If not, see <http://www.gnu.org/licenses/>.
+######################################################################
+
+import ase
+from ase.calculators.calculator import Calculator, CalculatorSetupError, all_changes
+import numpy as np
+import sander
+
+
+class SanderCalculator(Calculator):
+    kcalmol_to_eV = ase.units.kcal / ase.units.mol
+    implemented_properties = ["energy", "forces"]
+
+    def __init__(self, parm7, atoms):
+        super().__init__()
+        if sander.is_setup():
+            sander.cleanup()
+        sander.setup(
+            parm7, atoms.get_positions(), self._get_box(atoms), sander.gas_input()
+        )
+
+    def calculate(
+        self, atoms, properties=["energy", "forces"], system_changes=all_changes
+    ):
+        super().calculate(atoms, properties, system_changes)
+        sander.set_positions(atoms.get_positions())
+        box = self._get_box(atoms)
+        if box is not None:
+            sander.set_box(*box)
+
+        energy, forces = sander.energy_forces()
+        self.results = {
+            "energy": energy.tot * self.kcalmol_to_eV,
+            "forces": np.array(forces).reshape((-1, 3)) * self.kcalmol_to_eV,
+        }
+
+    @staticmethod
+    def _get_box(atoms):
+        if not atoms.get_pbc().all():
+            return None
+        cell = atoms.get_cell().flatten()
+        if len(cell) == 6:
+            return cell
+        if len(cell) == 3:
+            return np.concatenate([cell, [90.0, 90.0, 90.0]])
+        raise CalculatorSetupError(f"Cell {atoms.cell} is not supported")


### PR DESCRIPTION
This PR adds support for [rascal](https://github.com/lab-cosmo/librascal) as the in vacuo backend. This allows us to support system-specific in vacuo delta-learning models. The following plot shows a comparison of energies and gradients to the [torchani](https://github.com/aiqm/torchani) backend using 100 frames from a 100ps alanine-dipeptide trajectory.

![torchani_vs_rascal](https://github.com/lohedges/sander-mlmm/assets/648557/ac670cc8-1eb8-4e10-9109-909e9c2b9e6d)