### PR TITLE
Add support for mechanical embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ mlmm-server --backend cuda:1
 This would tell `PyTorch` that we want to use device index `1`. The same formatting
 works for the environment varialbe, e.g. `MLMM_DEVICE=cuda:1`.
 
+## Embedding method
+
+We support both _electrostatic_ and _mechanical_ embedding. Obviously we are
+advocating our electrostatic embedding scheme, but the use of mechanical
+embedding provides a useful reference for determining the benefit of
+using electrostatic embedding for a given system. The embedding method
+can be specified using the `MLMM_EMBEDDING` environment variable, or when
+launching the server, e.g.:
+
+```
+mlmm-server --embedding mechanical
+```
+
+The default option is (unsurprisingly) `electrostatic`.
+
 ## Why do we need an ML/MM server?
 
 The ML/MM implementation uses several ML frameworks to predict energies

--- a/bin/mlmm-server
+++ b/bin/mlmm-server
@@ -37,6 +37,7 @@ try:
 except:
     MLMM_PORT = None
 MLMM_MODEL = os.getenv("MLMM_MODEL")
+MLMM_EMBEDDING = os.getenv("MLMM_EMBEDDING")
 try:
     MLMM_NUM_CLIENTS = int(os.getenv("MLMM_NUM_CLIENTS"))
 except:
@@ -81,6 +82,13 @@ parser.add_argument("--host", type=str, help="the hostname.", required=False)
 parser.add_argument("--port", type=str, help="the port number", required=False)
 parser.add_argument(
     "--model", type=str, help="path to an ML/MM model file", required=False
+)
+parser.add_argument(
+    "--embedding",
+    type=str,
+    help="the embedding method to use",
+    choices=["electrostatic", "mechanical"],
+    required=False,
 )
 parser.add_argument(
     "--num-clients",
@@ -139,6 +147,8 @@ if args.port:
     MLMM_PORT = args.port
 if args.model:
     MLMM_MODEL = args.model
+if args.embedding:
+    MLMM_EMBEDDING = args.embedding
 if args.num_clients:
     MLMM_NUM_CLIENTS = args.num_clients
 if args.backend:
@@ -209,6 +219,7 @@ except:
 print("Initialising ML/MM calculator...")
 mlmm_calculator = MLMMCalculator(
     model=MLMM_MODEL,
+    embedding=MLMM_EMBEDDING,
     backend=MLMM_BACKEND,
     deepmd_model=DEEPMD_MODEL,
     rascal_model=RASCAL_MODEL,

--- a/mlmm/mlmm.py
+++ b/mlmm/mlmm.py
@@ -208,6 +208,7 @@ class MLMMCalculator:
     def __init__(
         self,
         model=None,
+        embedding="electrostatic",
         backend="torchani",
         deepmd_model=None,
         rascal_model=None,
@@ -220,6 +221,9 @@ class MLMMCalculator:
         model : str
             Path to the ML/MM embedding model parameter file. If None, then a
             default model will be used.
+
+        embedding : str
+            Whether to use "electrostatic" or "mechanical" embedding.
 
         backend : str
             The backend to use to compute in vacuo energies and gradients.
@@ -255,6 +259,14 @@ class MLMMCalculator:
             self._model = model
         else:
             self._model = self._default_model
+
+        if not isinstance(embedding, str):
+            raise TypeError("'embedding' must be of type 'str'")
+        embedding = embedding.replace(" ", "").lower()
+        if not embedding in ["electrostatic", "mechanical"]:
+            raise ValueError(
+                "'embedding' must be either 'electrostatic' or 'mechanical'"
+            )
 
         # Load the model parameters.
         try:


### PR DESCRIPTION
This PR adds support for mechanical embedding. This is achieved by using MM charges for the species supported by the ML/MM model, which can be obtained by using the `mm_charges` key in the model parameters. When mechanical embedding is selected, these charges will replace the core charges in the model. In addition, the valence charges are set to zero, as is the induced component of the energy.