### PR TITLE
Clarify alternative embedding methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,18 +136,21 @@ works for the environment varialbe, e.g. `MLMM_DEVICE=cuda:1`.
 
 ## Embedding method
 
-We support both _electrostatic_ and _mechanical_ embedding. Obviously we are
-advocating our electrostatic embedding scheme, but the use of mechanical
-embedding provides a useful reference for determining the benefit of
-using electrostatic embedding for a given system. The embedding method
-can be specified using the `MLMM_EMBEDDING` environment variable, or when
-launching the server, e.g.:
+We support both _electrostatic_, _mechanical_, and _MM_ embedding. Our
+implementation of mechanical embedding uses the model to predict charges for
+the QM region, but ignores the induced component of the potential. MM embedding
+allows the user to specify fixed MM charges for the QM atoms, with induction
+once again disabled. Obviously we are advocating our electrostatic embedding
+scheme, but the use of mechanical or MM embedding provides a useful reference
+for determining the benefit of using electrostatic embedding for a given system.
+The embedding method can be specified using the `MLMM_EMBEDDING` environment
+variable, or when launching the server, e.g.:
 
 ```
 mlmm-server --embedding mechanical
 ```
 
-The default option is (unsurprisingly) `electrostatic`. When using mechanical
+The default option is (unsurprisingly) `electrostatic`. When using MM
 embedding you will also need to specify MM charges for the atoms within the
 QM region. This can be done using the `--mm-charges` option, or via the
 `MLMM_MM_CHARGES` environment variable. The charges can be specified as a list

--- a/bin/mlmm-server
+++ b/bin/mlmm-server
@@ -93,7 +93,7 @@ parser.add_argument(
     "--embedding",
     type=str,
     help="the embedding method to use",
-    choices=["electrostatic", "mechanical"],
+    choices=["electrostatic", "mechanical", "mm"],
     required=False,
 )
 parser.add_argument(
@@ -181,9 +181,9 @@ if args.log is not None:
 
 # Validate the MM charges. Don't bother doing this if the user has
 # specified "electrostatic" embedding.
-if MLMM_EMBEDDING == "mechanical":
+if MLMM_EMBEDDING == "mm":
     if MLMM_MM_CHARGES is None:
-        raise ValueError("'mm_charges' are required when using 'mechanical' embedding")
+        raise ValueError("'mm_charges' are required when using 'mm' embedding")
 
     # Whether we are parsing a list of charges, rather than a file.
     is_list = False


### PR DESCRIPTION
This PR clarifies the alternative embedding methods that we support. These are:

* _mechanical_ embedding: This is an approximation of true mechanical embedding, where we use the embedding model to predict charges on the QM atoms, but ignore the induced component of the potential.
* _MM_ embedding: Here we allow the use to explicitly specify the MM charges to use as the core charge for atoms within the QM region. The valence charge is ignored, as is the induced component of the potential.